### PR TITLE
Speed Improvements

### DIFF
--- a/moto/rds3/models/__init__.py
+++ b/moto/rds3/models/__init__.py
@@ -48,14 +48,14 @@ class RDS3Backend(
             if backend not in [RDS3Backend, BaseBackend, object]:
                 backend.__init__(self)
         # Create RDS Alias
-        rds_key = self.kms.create_key(
-            policy="",
-            key_usage="ENCRYPT_DECRYPT",
-            key_spec=None,
-            description="Default master key that protects my RDS database volumes when no other key is defined",
-            tags=None,
-        )
-        self.kms.add_alias(rds_key.id, "alias/aws/rds")
+        # rds_key = self.kms.create_key(
+        #     policy="",
+        #     key_usage="ENCRYPT_DECRYPT",
+        #     key_spec=None,
+        #     description="Default master key that protects my RDS database volumes when no other key is defined",
+        #     tags=None,
+        # )
+        # self.kms.add_alias(rds_key.id, "alias/aws/rds")
 
     @property
     def ec2(self):

--- a/moto/rds3/responses.py
+++ b/moto/rds3/responses.py
@@ -11,9 +11,7 @@ MAX_RECORDS = 100
 # Do this once...
 # Need to find a better place to put this, or cache it somehow.
 client = boto3.client("rds", region_name="us-east-1")
-api_to_method_mapping = {
-    v: k for k, v in client.meta.method_to_api_mapping.items()
-}
+api_to_method_mapping = {v: k for k, v in client.meta.method_to_api_mapping.items()}
 
 
 class RDSResponse(BaseResponse):

--- a/moto/rds3/responses.py
+++ b/moto/rds3/responses.py
@@ -8,6 +8,13 @@ from .serialize import create_serializer
 
 MAX_RECORDS = 100
 
+# Do this once...
+# Need to find a better place to put this, or cache it somehow.
+client = boto3.client("rds", region_name="us-east-1")
+api_to_method_mapping = {
+    v: k for k, v in client.meta.method_to_api_mapping.items()
+}
+
 
 class RDSResponse(BaseResponse):
     @property
@@ -30,13 +37,14 @@ class RDSResponse(BaseResponse):
         return utils.parse_query_parameters(self._get_action(), self.querystring)
 
     def call_action(self):
-        client = boto3.client("rds", region_name="us-east-1")
+        # Moved this section up to globals just for a bit of speed boost...
+        # client = boto3.client("rds", region_name="us-east-1")
         # Use the boto ability to add methods/attrs to the client class to put this on there
         # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/events.html
         # Eh... will we have access to the meta attribute at that point?
-        api_to_method_mapping = {
-            v: k for k, v in client.meta.method_to_api_mapping.items()
-        }
+        # api_to_method_mapping = {
+        #     v: k for k, v in client.meta.method_to_api_mapping.items()
+        # }
         action = self._get_action()
         operation_model = client.meta.service_model.operation_model(action)
         action_method = api_to_method_mapping[action]


### PR DESCRIPTION
Creating the RDS encryption key was taking 70% of the time in the test runs, due to calling RSA_generate_key

We don't actually need this at the moment for our RDS tests to pass, so commenting out for now in order to speed things up.

Also moved the client creation in responses up to module level in order to avoid decoding the service JSON every request.