### PR TITLE
CFSB-1181: Describe and modify db (cluster) snapshot

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -4946,7 +4946,7 @@
 - [ ] describe_db_cluster_endpoints
 - [ ] describe_db_cluster_parameter_groups
 - [ ] describe_db_cluster_parameters
-- [ ] describe_db_cluster_snapshot_attributes
+- [X] describe_db_cluster_snapshot_attributes
 - [X] describe_db_cluster_snapshots
 - [X] describe_db_clusters
 - [ ] describe_db_engine_versions
@@ -4960,7 +4960,7 @@
 - [ ] describe_db_proxy_target_groups
 - [ ] describe_db_proxy_targets
 - [ ] describe_db_security_groups
-- [ ] describe_db_snapshot_attributes
+- [X] describe_db_snapshot_attributes
 - [ ] describe_db_snapshots
 - [ ] describe_db_subnet_groups
 - [ ] describe_engine_default_cluster_parameters
@@ -4989,14 +4989,14 @@
 - [X] modify_db_cluster
 - [ ] modify_db_cluster_endpoint
 - [ ] modify_db_cluster_parameter_group
-- [ ] modify_db_cluster_snapshot_attribute
+- [X] modify_db_cluster_snapshot_attribute
 - [X] modify_db_instance
 - [X] modify_db_parameter_group
 - [ ] modify_db_proxy
 - [ ] modify_db_proxy_endpoint
 - [ ] modify_db_proxy_target_group
 - [ ] modify_db_snapshot
-- [ ] modify_db_snapshot_attribute
+- [X] modify_db_snapshot_attribute
 - [X] modify_db_subnet_group
 - [ ] modify_event_subscription
 - [ ] modify_global_cluster

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -4900,7 +4900,7 @@
 - [ ] backtrack_db_cluster
 - [X] cancel_export_task
 - [ ] copy_db_cluster_parameter_group
-- [ ] copy_db_cluster_snapshot
+- [X] copy_db_cluster_snapshot
 - [ ] copy_db_parameter_group
 - [ ] copy_db_snapshot
 - [ ] copy_option_group

--- a/docs/docs/services/rds.rst
+++ b/docs/docs/services/rds.rst
@@ -33,7 +33,7 @@ rds
 - [ ] authorize_db_security_group_ingress
 - [ ] backtrack_db_cluster
 - [X] cancel_export_task
-- [ ] copy_db_cluster_parameter_group
+- [X] copy_db_cluster_parameter_group
 - [ ] copy_db_cluster_snapshot
 - [ ] copy_db_parameter_group
 - [ ] copy_db_snapshot

--- a/docs/docs/services/rds.rst
+++ b/docs/docs/services/rds.rst
@@ -80,7 +80,7 @@ rds
 - [ ] describe_db_cluster_endpoints
 - [ ] describe_db_cluster_parameter_groups
 - [ ] describe_db_cluster_parameters
-- [ ] describe_db_cluster_snapshot_attributes
+- [X] describe_db_cluster_snapshot_attributes
 - [X] describe_db_cluster_snapshots
 - [X] describe_db_clusters
 - [ ] describe_db_engine_versions
@@ -94,7 +94,7 @@ rds
 - [ ] describe_db_proxy_target_groups
 - [ ] describe_db_proxy_targets
 - [ ] describe_db_security_groups
-- [ ] describe_db_snapshot_attributes
+- [X] describe_db_snapshot_attributes
 - [ ] describe_db_snapshots
 - [ ] describe_db_subnet_groups
 - [ ] describe_engine_default_cluster_parameters
@@ -123,14 +123,14 @@ rds
 - [X] modify_db_cluster
 - [ ] modify_db_cluster_endpoint
 - [ ] modify_db_cluster_parameter_group
-- [ ] modify_db_cluster_snapshot_attribute
+- [X] modify_db_cluster_snapshot_attribute
 - [X] modify_db_instance
 - [X] modify_db_parameter_group
 - [ ] modify_db_proxy
 - [ ] modify_db_proxy_endpoint
 - [ ] modify_db_proxy_target_group
 - [ ] modify_db_snapshot
-- [ ] modify_db_snapshot_attribute
+- [X] modify_db_snapshot_attribute
 - [X] modify_db_subnet_group
 - [ ] modify_event_subscription
 - [ ] modify_global_cluster

--- a/moto/rds3/exceptions.py
+++ b/moto/rds3/exceptions.py
@@ -142,6 +142,16 @@ class SnapshotQuotaExceeded(RDSError):
     fmt = "The request cannot be processed because it would exceed the maximum number of snapshots."
 
 
+class SharedSnapshotQuotaExceeded(RDSError):
+
+    fmt = "The request cannot be processed because it would exceed the maximum number of snapshots."
+
+
+class InvalidDBClusterSnapshotStateFault(RDSError):
+
+    fmt = "automated snapshots cannot be modified."
+
+
 class InvalidParameterValue(RDSError):
 
     code = "InvalidParameterValue"

--- a/moto/rds3/exceptions.py
+++ b/moto/rds3/exceptions.py
@@ -147,6 +147,14 @@ class SharedSnapshotQuotaExceeded(RDSError):
     fmt = "The request cannot be processed because it would exceed the maximum number of snapshots."
 
 
+class KMSKeyNotAccessibleFault(RDSError):
+
+    fmt = "Specified KMS key [{key_id}] does not exist, is not enabled or you do not have permissions to access it."
+
+    def __init__(self, key_id):
+        super().__init__(key_id=key_id)
+
+
 class InvalidDBClusterSnapshotStateFault(RDSError):
 
     fmt = "automated snapshots cannot be modified."

--- a/moto/rds3/models/db_cluster_snapshot.py
+++ b/moto/rds3/models/db_cluster_snapshot.py
@@ -33,8 +33,12 @@ class DBClusterSnapshot(TaggableRDSResource, BaseRDSModel):
         self.snapshot_type = snapshot_type
         self.percent_progress = 100
         self.status = "available"
+        # If tags are provided at creation, AWS does *not* copy tags from the
+        # db_cluster (even if copy_tags_to_snapshot is True).
         if tags:
             self.add_tags(tags)
+        elif db_cluster.copy_tags_to_snapshot:
+            self.add_tags(db_cluster.tags)
         self.cluster = copy.copy(db_cluster)
         self.allocated_storage = self.cluster.allocated_storage
         self.cluster_create_time = self.cluster.created

--- a/moto/rds3/models/db_cluster_snapshot.py
+++ b/moto/rds3/models/db_cluster_snapshot.py
@@ -144,6 +144,7 @@ class DBClusterSnapshotBackend:
         target_db_cluster_snapshot_identifier,
         kms_key_id=None,
         tags=None,
+        copy_tags=False,
     ):
         if source_db_cluster_snapshot_identifier not in self.db_cluster_snapshots:
             raise DBClusterSnapshotNotFound(source_db_cluster_snapshot_identifier)
@@ -164,6 +165,9 @@ class DBClusterSnapshotBackend:
         source_db_cluster_snapshot = self.get_db_cluster_snapshot(
             source_db_cluster_snapshot_identifier
         )
+        # If tags are present, copy_tags is ignored
+        if copy_tags and not tags:
+            tags = source_db_cluster_snapshot.tags
         target_db_cluster_snapshot = DBClusterSnapshot(
             self,
             target_db_cluster_snapshot_identifier,

--- a/moto/rds3/models/db_cluster_snapshot.py
+++ b/moto/rds3/models/db_cluster_snapshot.py
@@ -1,4 +1,5 @@
 import copy
+import os
 
 from collections import OrderedDict
 from .base import BaseRDSModel
@@ -6,6 +7,10 @@ from .tag import TaggableRDSResource
 from ..exceptions import (
     DBClusterSnapshotAlreadyExists,
     DBClusterSnapshotNotFound,
+    InvalidParameterValue,
+    InvalidParameterCombination,
+    SharedSnapshotQuotaExceeded,
+    InvalidDBClusterSnapshotStateFault,
 )
 
 
@@ -33,6 +38,9 @@ class DBClusterSnapshot(TaggableRDSResource, BaseRDSModel):
         self.master_username = self.cluster.master_username
         self.port = self.cluster.port
         self.storage_encrypted = self.cluster.storage_encrypted
+        self.snapshot_attributes = DBClusterSnapshotAttributeResult(
+            db_cluster_snapshot_identifier=self.db_cluster_snapshot_identifier
+        )
 
     @property
     def resource_id(self):
@@ -45,6 +53,46 @@ class DBClusterSnapshot(TaggableRDSResource, BaseRDSModel):
     @property
     def snapshot_create_time(self):
         return self.created
+
+
+class DBClusterSnapshotAttribute:
+    ALLOWED_ATTRIBUTE_NAMES = ["restore"]
+
+    def __init__(self, attribute_name, attribute_values):
+        self.attribute_name = attribute_name
+        self.attribute_values = attribute_values
+
+    @staticmethod
+    def build_from_values(
+        attribute_name, attribute_values, values_to_add, values_to_remove
+    ):
+        if not values_to_add:
+            values_to_add = []
+        if not values_to_remove:
+            values_to_remove = []
+        if attribute_name not in DBClusterSnapshotAttribute.ALLOWED_ATTRIBUTE_NAMES:
+            raise InvalidParameterValue(
+                f"Invalid cluster snapshot attribute {attribute_name}"
+            )
+        common_values = set(values_to_add).intersection(values_to_remove)
+        if common_values:
+            raise InvalidParameterCombination(
+                "A customer Id may not appear in both the add list and remove list. "
+                + f"{common_values}"
+            )
+        add = attribute_values + values_to_add
+        attribute_values = [value for value in add if value not in values_to_remove]
+        if len(attribute_values) > os.getenv("MAX_SHARED_ACCOUNTS", 20):
+            raise SharedSnapshotQuotaExceeded()
+        return DBClusterSnapshotAttribute(attribute_name, attribute_values)
+
+
+class DBClusterSnapshotAttributeResult:
+    def __init__(self, db_cluster_snapshot_identifier):
+        self.db_cluster_snapshot_identifier = db_cluster_snapshot_identifier
+        self.db_cluster_snapshot_attributes = [
+            DBClusterSnapshotAttribute(attribute_name="restore", attribute_values=[])
+        ]
 
 
 class DBClusterSnapshotBackend:
@@ -81,7 +129,7 @@ class DBClusterSnapshotBackend:
         db_cluster_identifier=None,
         db_cluster_snapshot_identifier=None,
         snapshot_type=None,
-        **_
+        **_,
     ):
         if db_cluster_snapshot_identifier:
             return [self.get_db_cluster_snapshot(db_cluster_snapshot_identifier)]
@@ -96,3 +144,37 @@ class DBClusterSnapshotBackend:
                         db_cluster_snapshots.append(snapshot)
             return db_cluster_snapshots
         return self.db_cluster_snapshots.values()
+
+    def describe_db_cluster_snapshot_attributes(
+        self,
+        db_cluster_snapshot_identifier,
+    ):
+        cluster_snapshot = self.get_db_cluster_snapshot(db_cluster_snapshot_identifier)
+        return cluster_snapshot.snapshot_attributes
+
+    def modify_db_cluster_snapshot_attribute(
+        self,
+        db_cluster_snapshot_identifier,
+        attribute_name,
+        values_to_add=None,
+        values_to_remove=None,
+    ):
+        cluster_snapshot = self.get_db_cluster_snapshot(db_cluster_snapshot_identifier)
+        if cluster_snapshot.snapshot_type != "manual":
+            raise InvalidDBClusterSnapshotStateFault()
+            pass
+        attribute_values = (
+            cluster_snapshot.snapshot_attributes.db_cluster_snapshot_attributes[
+                0
+            ].attribute_values
+        )
+        updated_attribute_values = DBClusterSnapshotAttribute.build_from_values(
+            attribute_name=attribute_name,
+            attribute_values=attribute_values,
+            values_to_add=values_to_add,
+            values_to_remove=values_to_remove,
+        )
+        cluster_snapshot.snapshot_attributes.db_cluster_snapshot_attributes[
+            0
+        ] = updated_attribute_values
+        return cluster_snapshot.snapshot_attributes

--- a/moto/rds3/models/db_snapshot.py
+++ b/moto/rds3/models/db_snapshot.py
@@ -13,6 +13,9 @@ from ..exceptions import (
     DBSnapshotNotFound,
     InvalidDBSnapshotIdentifierValue,
     SnapshotQuotaExceeded,
+    InvalidParameterValue,
+    InvalidParameterCombination,
+    SharedSnapshotQuotaExceeded,
 )
 
 
@@ -93,6 +96,9 @@ class DBSnapshot(TaggableRDSResource, EventMixin, BaseRDSModel):
         self.master_username = self.db_instance.master_username
         self.storage_type = self.db_instance.storage_type
         self.iops = self.db_instance.iops
+        self.snapshot_attributes = DBSnapshotAttributeResult(
+            db_snapshot_identifier=self.db_snapshot_identifier
+        )
 
     @property
     def resource_id(self):
@@ -123,6 +129,44 @@ class DBInstanceAutomatedBackup:
         if self.db_instance_identifier not in self.backend.db_instances:
             status = "retained"
         return status
+
+
+class DBSnapshotAttribute:
+    ALLOWED_ATTRIBUTE_NAMES = ["restore"]
+
+    def __init__(self, attribute_name, attribute_values):
+        self.attribute_name = attribute_name
+        self.attribute_values = attribute_values
+
+    @staticmethod
+    def build_from_values(
+        attribute_name, attribute_values, values_to_add, values_to_remove
+    ):
+        if not values_to_add:
+            values_to_add = []
+        if not values_to_remove:
+            values_to_remove = []
+        if attribute_name not in DBSnapshotAttribute.ALLOWED_ATTRIBUTE_NAMES:
+            raise InvalidParameterValue(f"Invalid snapshot attribute {attribute_name}")
+        common_values = set(values_to_add).intersection(values_to_remove)
+        if common_values:
+            raise InvalidParameterCombination(
+                "A customer Id may not appear in both the add list and remove list. "
+                + f"{common_values}"
+            )
+        add = attribute_values + values_to_add
+        attribute_values = [value for value in add if value not in values_to_remove]
+        if len(attribute_values) > os.getenv("MAX_SHARED_ACCOUNTS", 20):
+            raise SharedSnapshotQuotaExceeded()
+        return DBSnapshotAttribute(attribute_name, attribute_values)
+
+
+class DBSnapshotAttributeResult:
+    def __init__(self, db_snapshot_identifier):
+        self.db_snapshot_identifier = db_snapshot_identifier
+        self.db_snapshot_attributes = [
+            DBSnapshotAttribute(attribute_name="restore", attribute_values=[])
+        ]
 
 
 class DBSnapshotBackend:
@@ -229,3 +273,34 @@ class DBSnapshotBackend:
         return [
             DBInstanceAutomatedBackup(self, k, v) for k, v in snapshots_grouped.items()
         ]
+
+    def describe_db_snapshot_attributes(
+        self,
+        db_snapshot_identifier,
+    ):
+        snapshot = self.get_db_snapshot(db_snapshot_identifier)
+        return snapshot.snapshot_attributes
+
+    def modify_db_snapshot_attribute(
+        self,
+        db_snapshot_identifier,
+        attribute_name,
+        values_to_add=None,
+        values_to_remove=None,
+    ):
+        snapshot = self.get_db_snapshot(db_snapshot_identifier)
+        if snapshot.snapshot_type != "manual":
+            raise InvalidDBSnapshotIdentifierValue(db_snapshot_identifier)
+        attribute_values = snapshot.snapshot_attributes.db_snapshot_attributes[
+            0
+        ].attribute_values
+        updated_attribute_values = DBSnapshotAttribute.build_from_values(
+            attribute_name=attribute_name,
+            attribute_values=attribute_values,
+            values_to_add=values_to_add,
+            values_to_remove=values_to_remove,
+        )
+        snapshot.snapshot_attributes.db_snapshot_attributes[
+            0
+        ] = updated_attribute_values
+        return snapshot.snapshot_attributes

--- a/moto/rds3/models/db_snapshot.py
+++ b/moto/rds3/models/db_snapshot.py
@@ -185,6 +185,7 @@ class DBSnapshotBackend:
         target_db_snapshot_identifier,
         kms_key_id=None,
         tags=None,
+        copy_tags=False,
     ):
         if target_db_snapshot_identifier in self.db_snapshots:
             raise DBSnapshotAlreadyExists(target_db_snapshot_identifier)
@@ -200,6 +201,9 @@ class DBSnapshotBackend:
         except Exception:
             raise KMSKeyNotAccessibleFault(str(kms_key_id))
         source_snapshot = self.get_db_snapshot(source_db_snapshot_identifier)
+        # If tags are present, copy_tags is ignored
+        if copy_tags and not tags:
+            tags = source_snapshot.tags
         target_snapshot = DBSnapshot(
             self,
             target_db_snapshot_identifier,

--- a/tests/test_rds3/test_db_cluster_snapshots.py
+++ b/tests/test_rds3/test_db_cluster_snapshots.py
@@ -3,6 +3,7 @@ from botocore.exceptions import ClientError
 
 from . import mock_rds
 from sure import this
+import pytest
 
 
 test_tags = [
@@ -108,3 +109,249 @@ def test_delete_non_existent_db_cluster_snapshot_fails():
     client.delete_db_cluster_snapshot.when.called_with(
         DBClusterSnapshotIdentifier="non-existent"
     ).should.throw(ClientError, "not found")
+
+
+@mock_rds
+def test_describe_and_modify_cluster_snapshot_attributes():
+    client = boto3.client("rds", region_name="us-west-2")
+    client.create_db_cluster(
+        DBClusterIdentifier="cluster-1",
+        DatabaseName="db_name",
+        Engine="aurora-postgresql",
+        MasterUsername="root",
+        MasterUserPassword="password",
+        Port=1234,
+    )
+    cluster_snapshot = client.create_db_cluster_snapshot(
+        DBClusterSnapshotIdentifier="cluster-snap", DBClusterIdentifier="cluster-1"
+    ).get("DBClusterSnapshot")
+    cluster_snapshot["DBClusterSnapshotIdentifier"].should.equal("cluster-snap")
+    cluster_snapshot_attribute_results = client.describe_db_cluster_snapshot_attributes(
+        DBClusterSnapshotIdentifier=cluster_snapshot["DBClusterSnapshotIdentifier"]
+    )
+    cluster_snapshot_attribute_results["DBClusterSnapshotAttributesResult"][
+        "DBClusterSnapshotIdentifier"
+    ].should.equal("cluster-snap")
+    len(
+        cluster_snapshot_attribute_results["DBClusterSnapshotAttributesResult"][
+            "DBClusterSnapshotAttributes"
+        ]
+    ).should.equal(1)
+    cluster_snapshot_attribute_results["DBClusterSnapshotAttributesResult"][
+        "DBClusterSnapshotAttributes"
+    ][0]["AttributeName"].should.equal("restore")
+    len(
+        cluster_snapshot_attribute_results["DBClusterSnapshotAttributesResult"][
+            "DBClusterSnapshotAttributes"
+        ][0]["AttributeValues"]
+    ).should.equal(0)
+
+    # Modify the snapshot attribute (Add)
+    customer_accounts_add = ["123", "456"]
+    cluster_snapshot_attribute_result = client.modify_db_cluster_snapshot_attribute(
+        DBClusterSnapshotIdentifier=cluster_snapshot["DBClusterSnapshotIdentifier"],
+        AttributeName="restore",
+        ValuesToAdd=customer_accounts_add,
+    )
+    cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+        "DBClusterSnapshotIdentifier"
+    ].should.equal("cluster-snap")
+    len(
+        cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+            "DBClusterSnapshotAttributes"
+        ]
+    ).should.equal(1)
+    cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+        "DBClusterSnapshotAttributes"
+    ][0]["AttributeName"].should.equal("restore")
+    len(
+        cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+            "DBClusterSnapshotAttributes"
+        ][0]["AttributeValues"]
+    ).should.equal(2)
+    cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+        "DBClusterSnapshotAttributes"
+    ][0]["AttributeValues"].should.equal(customer_accounts_add)
+
+    # Modify the snapshot attribute (Add + Remove)
+    customer_accounts_add = ["789"]
+    customer_accounts_remove = ["123", "456"]
+    cluster_snapshot_attribute_result = client.modify_db_cluster_snapshot_attribute(
+        DBClusterSnapshotIdentifier=cluster_snapshot["DBClusterSnapshotIdentifier"],
+        AttributeName="restore",
+        ValuesToAdd=customer_accounts_add,
+        ValuesToRemove=customer_accounts_remove,
+    )
+    cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+        "DBClusterSnapshotIdentifier"
+    ].should.equal("cluster-snap")
+    len(
+        cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+            "DBClusterSnapshotAttributes"
+        ]
+    ).should.equal(1)
+    cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+        "DBClusterSnapshotAttributes"
+    ][0]["AttributeName"].should.equal("restore")
+    len(
+        cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+            "DBClusterSnapshotAttributes"
+        ][0]["AttributeValues"]
+    ).should.equal(1)
+    cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+        "DBClusterSnapshotAttributes"
+    ][0]["AttributeValues"].should.equal(customer_accounts_add)
+
+    # Modify the snapshot attribute (Add + Remove)
+    customer_accounts_remove = ["789"]
+    cluster_snapshot_attribute_result = client.modify_db_cluster_snapshot_attribute(
+        DBClusterSnapshotIdentifier=cluster_snapshot["DBClusterSnapshotIdentifier"],
+        AttributeName="restore",
+        ValuesToRemove=customer_accounts_remove,
+    )
+    cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+        "DBClusterSnapshotIdentifier"
+    ].should.equal("cluster-snap")
+    len(
+        cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+            "DBClusterSnapshotAttributes"
+        ]
+    ).should.equal(1)
+    cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+        "DBClusterSnapshotAttributes"
+    ][0]["AttributeName"].should.equal("restore")
+    len(
+        cluster_snapshot_attribute_result["DBClusterSnapshotAttributesResult"][
+            "DBClusterSnapshotAttributes"
+        ][0]["AttributeValues"]
+    ).should.equal(0)
+
+
+@mock_rds
+def test_describe_snapshot_attributes_with_invalid_cluster_snapshot_id():
+    client = boto3.client("rds", region_name="us-west-2")
+    with pytest.raises(ClientError) as ex:
+        client.describe_db_cluster_snapshot_attributes(
+            DBClusterSnapshotIdentifier="invalid_snapshot_id",
+        )
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(404)
+    ex.value.response["Error"]["Code"].should.equal("DBClusterSnapshotNotFoundFault")
+
+
+@mock_rds
+def test_modify_snapshot_attributes_with_invalid_cluster_snapshot_id():
+    client = boto3.client("rds", region_name="us-west-2")
+    with pytest.raises(ClientError) as ex:
+        client.modify_db_cluster_snapshot_attribute(
+            DBClusterSnapshotIdentifier="invalid_snapshot_id",
+            AttributeName="restore",
+            ValuesToRemove=["123"],
+        )
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(404)
+    ex.value.response["Error"]["Code"].should.equal("DBClusterSnapshotNotFoundFault")
+
+
+@mock_rds
+def test_modify_snapshot_attributes_with_invalid_attribute_name():
+    client = boto3.client("rds", region_name="us-west-2")
+    client.create_db_cluster(
+        DBClusterIdentifier="cluster-1",
+        DatabaseName="db_name",
+        Engine="aurora-postgresql",
+        MasterUsername="root",
+        MasterUserPassword="password",
+        Port=1234,
+    )
+    cluster_snapshot = client.create_db_cluster_snapshot(
+        DBClusterSnapshotIdentifier="cluster-snap", DBClusterIdentifier="cluster-1"
+    ).get("DBClusterSnapshot")
+    cluster_snapshot["DBClusterSnapshotIdentifier"].should.equal("cluster-snap")
+
+    with pytest.raises(ClientError) as ex:
+        client.modify_db_cluster_snapshot_attribute(
+            DBClusterSnapshotIdentifier=cluster_snapshot["DBClusterSnapshotIdentifier"],
+            AttributeName="invalid_name",
+            ValuesToAdd=["123"],
+        )
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    ex.value.response["Error"]["Code"].should.equal("InvalidParameterValue")
+
+
+@mock_rds
+def test_modify_snapshot_attributes_with_invalid_parameter_combination():
+    client = boto3.client("rds", region_name="us-west-2")
+    client.create_db_cluster(
+        DBClusterIdentifier="cluster-1",
+        DatabaseName="db_name",
+        Engine="aurora-postgresql",
+        MasterUsername="root",
+        MasterUserPassword="password",
+        Port=1234,
+    )
+    cluster_snapshot = client.create_db_cluster_snapshot(
+        DBClusterSnapshotIdentifier="cluster-snap", DBClusterIdentifier="cluster-1"
+    ).get("DBClusterSnapshot")
+    cluster_snapshot["DBClusterSnapshotIdentifier"].should.equal("cluster-snap")
+
+    with pytest.raises(ClientError) as ex:
+        client.modify_db_cluster_snapshot_attribute(
+            DBClusterSnapshotIdentifier=cluster_snapshot["DBClusterSnapshotIdentifier"],
+            AttributeName="restore",
+            ValuesToAdd=["123", "456"],
+            ValuesToRemove=["456"],
+        )
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    ex.value.response["Error"]["Code"].should.equal("InvalidParameterCombination")
+
+
+@mock_rds
+def test_modify_snapshot_attributes_exceeding_number_of_shared_accounts():
+    client = boto3.client("rds", region_name="us-west-2")
+    client.create_db_cluster(
+        DBClusterIdentifier="cluster-1",
+        DatabaseName="db_name",
+        Engine="aurora-postgresql",
+        MasterUsername="root",
+        MasterUserPassword="password",
+        Port=1234,
+    )
+    cluster_snapshot = client.create_db_cluster_snapshot(
+        DBClusterSnapshotIdentifier="cluster-snap", DBClusterIdentifier="cluster-1"
+    ).get("DBClusterSnapshot")
+    cluster_snapshot["DBClusterSnapshotIdentifier"].should.equal("cluster-snap")
+
+    customer_accounts_add = [str(x) for x in range(30)]
+    with pytest.raises(ClientError) as ex:
+        client.modify_db_cluster_snapshot_attribute(
+            DBClusterSnapshotIdentifier=cluster_snapshot["DBClusterSnapshotIdentifier"],
+            AttributeName="restore",
+            ValuesToAdd=customer_accounts_add,
+        )
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    ex.value.response["Error"]["Code"].should.equal("SharedSnapshotQuotaExceeded")
+
+
+@mock_rds
+def test_modify_snapshot_attributes_for_automated_snapshot():
+    client = boto3.client("rds", region_name="us-west-2")
+    client.create_db_cluster(
+        DBClusterIdentifier="cluster-1",
+        DatabaseName="db_name",
+        Engine="aurora-postgresql",
+        MasterUsername="root",
+        MasterUserPassword="password",
+        Port=1234,
+    )
+    # Automated snapshots
+    auto_snapshot = client.describe_db_cluster_snapshots(MaxRecords=20).get(
+        "DBClusterSnapshots"
+    )[0]
+    with pytest.raises(ClientError) as ex:
+        client.modify_db_cluster_snapshot_attribute(
+            DBClusterSnapshotIdentifier=auto_snapshot["DBClusterSnapshotIdentifier"],
+            AttributeName="restore",
+        )
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    ex.value.response["Error"]["Code"].should.equal(
+        "InvalidDBClusterSnapshotStateFault"
+    )

--- a/tests/test_rds3/test_db_snapshots.py
+++ b/tests/test_rds3/test_db_snapshots.py
@@ -345,7 +345,7 @@ def test_describe_and_modify_snapshot_attributes():
 
 
 @mock_rds
-def test_describe_snapshot_attributes_with_invalid_snapshot_id():
+def test_describe_snapshot_attributes_fails_with_invalid_snapshot_identifier():
     client = boto3.client("rds", region_name="us-west-2")
     with pytest.raises(ClientError) as ex:
         client.describe_db_snapshot_attributes(
@@ -356,7 +356,7 @@ def test_describe_snapshot_attributes_with_invalid_snapshot_id():
 
 
 @mock_rds
-def test_modify_snapshot_attributes_with_invalid_snapshot_id():
+def test_modify_snapshot_attributes_fails_with_invalid_snapshot_id():
     client = boto3.client("rds", region_name="us-west-2")
     with pytest.raises(ClientError) as ex:
         client.modify_db_snapshot_attribute(
@@ -369,7 +369,7 @@ def test_modify_snapshot_attributes_with_invalid_snapshot_id():
 
 
 @mock_rds
-def test_modify_snapshot_attributes_with_invalid_attribute_name():
+def test_modify_snapshot_attributes_fails_with_invalid_attribute_name():
     instance_id = "test-instance"
     client = boto3.client("rds", region_name="us-west-2")
     client.create_db_instance(
@@ -398,7 +398,7 @@ def test_modify_snapshot_attributes_with_invalid_attribute_name():
 
 
 @mock_rds
-def test_modify_snapshot_attributes_with_invalid_parameter_combination():
+def test_modify_snapshot_attributes_fails_with_invalid_parameter_combination():
     instance_id = "test-instance"
     client = boto3.client("rds", region_name="us-west-2")
     client.create_db_instance(
@@ -428,7 +428,7 @@ def test_modify_snapshot_attributes_with_invalid_parameter_combination():
 
 
 @mock_rds
-def test_modify_snapshot_attributes_exceeding_number_of_shared_accounts():
+def test_modify_snapshot_attributes_fails_when_exceeding_number_of_shared_accounts():
     instance_id = "test-instance"
     client = boto3.client("rds", region_name="us-west-2")
     client.create_db_instance(
@@ -458,7 +458,7 @@ def test_modify_snapshot_attributes_exceeding_number_of_shared_accounts():
 
 
 @mock_rds
-def test_modify_snapshot_attributes_for_automated_snapshot():
+def test_modify_snapshot_attributes_fails_for_automated_snapshot():
     client = boto3.client("rds", region_name="us-west-2")
     client.create_db_instance(
         DBInstanceIdentifier="test-instance",


### PR DESCRIPTION
Handles the following 4 APIs:
[DescribeDBClusterSnapshotAttributes - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusterSnapshotAttributes.html) 

[DescribeDBSnapshotAttributes - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBSnapshotAttributes.html) 

[ModifyDBClusterSnapshotAttribute - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBClusterSnapshotAttribute.html) 

[ModifyDBSnapshotAttribute - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBSnapshotAttribute.html)