### PR TITLE
Introduce CACertificate identifier

### DIFF
--- a/moto/rds3/models/db_cluster.py
+++ b/moto/rds3/models/db_cluster.py
@@ -134,6 +134,7 @@ class DBCluster(TaggableRDSResource, EventMixin, BaseRDSModel):
     @property
     def latest_restorable_time(self):
         from moto.core.utils import iso_8601_datetime_with_milliseconds
+
         return iso_8601_datetime_with_milliseconds(datetime.datetime.now())
 
     @property

--- a/moto/rds3/models/db_instance.py
+++ b/moto/rds3/models/db_instance.py
@@ -62,6 +62,7 @@ class DBInstance(TaggableRDSResource, EventMixin, BaseRDSModel):
         tags=None,
         vpc_security_group_ids=None,
         deletion_protection=False,
+        ca_certificate_identifier="rds-ca-default",
         **kwargs,
     ):
         super().__init__(backend)
@@ -105,6 +106,7 @@ class DBInstance(TaggableRDSResource, EventMixin, BaseRDSModel):
         self._db_parameter_groups = [
             {"name": self.db_parameter_group_name, "status": "in-sync"}
         ]
+        self.ca_certificate_identifier = ca_certificate_identifier
 
         self.license_model = license_model
 
@@ -241,6 +243,7 @@ class DBInstance(TaggableRDSResource, EventMixin, BaseRDSModel):
     @property
     def latest_restorable_time(self):
         from moto.core.utils import iso_8601_datetime_with_milliseconds
+
         return iso_8601_datetime_with_milliseconds(datetime.datetime.now())
 
     def update(self, db_kwargs):

--- a/tests/test_rds3/test_db_instances.py
+++ b/tests/test_rds3/test_db_instances.py
@@ -123,6 +123,26 @@ def test_max_allocated_storage():
 
 
 @mock_rds
+def test_ca_certificate_identifier():
+    client = boto3.client("rds", region_name="us-west-2")
+    # Check for CACertificateIdentifier default value
+    _, details = create_db_instance(client)
+    details["CACertificateIdentifier"].should.equal("rds-ca-default")
+    # Set at creation time.
+    identifier, _ = create_db_instance(client, CACertificateIdentifier="rds-ca-2019")
+    # Get the value using describe_db_instances
+    details = client.describe_db_instances(DBInstanceIdentifier=identifier)[
+        "DBInstances"
+    ][0]
+    details["CACertificateIdentifier"].should.equal("rds-ca-2019")
+    # Update the value
+    details = client.modify_db_instance(
+        DBInstanceIdentifier=identifier, CACertificateIdentifier="rds-ca-2024"
+    )["DBInstance"]
+    details["CACertificateIdentifier"].should.equal("rds-ca-2024")
+
+
+@mock_rds
 def test_restore_db_instance_to_point_in_time():
     client = boto3.client("rds", region_name="us-west-2")
     source_identifier, details_source = create_db_instance(


### PR DESCRIPTION
Introduce CACertificateIdentifier param as part of the following APIs

1. create_db_instance
2. modiify_db_instance
3. describe_db_instances