### PR TITLE
Exclude broken `botocore` version(s)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ project_urls =
 python_requires = >=3.8
 install_requires =
     boto3>=1.9.201
-    botocore>=1.14.0
+    botocore>=1.14.0,<1.35.45
     cryptography>=3.3.1
     requests>=2.5
     xmltodict


### PR DESCRIPTION
Version 1.35.45 of `botocore` contains a regression that breaks some AWS API actions (both mocked and non-mocked).

Temporarily constraining the allowed `botocore` versions until a fix is released.